### PR TITLE
Store rapps catkin package information

### DIFF
--- a/rocon_python_utils/src/rocon_python_utils/ros/resources.py
+++ b/rocon_python_utils/src/rocon_python_utils/ros/resources.py
@@ -103,7 +103,7 @@ def resource_index_from_package_exports(export_tag, package_paths=None, package_
                 if not os.path.isfile(resource_filename):
                     invalid_resources[resource_name] = resource_filename
                 else:
-                    resources[resource_name] = resource_filename
+                    resources[resource_name] = (resource_filename, package)
     return (resources, invalid_resources)
 
 


### PR DESCRIPTION
This branch adds the Catkin package information to every discovered Rapp.

Required by https://github.com/esteve/rocon_app_platform/tree/rocon_dependencies
