### PR TITLE
rocon_uri parse provide all parsed information

### DIFF
--- a/rocon_uri/scripts/rocon_uri
+++ b/rocon_uri/scripts/rocon_uri
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#       
+#
 # License: BSD
 #   https://raw.github.com/robotics-in-concert/tools/license/LICENSE
 #
@@ -34,6 +34,13 @@ def _rocon_uri_cmd_parse(rocon_uri_string):
     try:
         uri = rocon_uri.RoconURI(rocon_uri_string)
         print("\n\t" + console.bold + "'" + rocon_uri_string + "'" + console.reset + console.green + " is a valid rocon uri\n" + console.reset)
+        print("\t" + console.bold + "'Concert Name'          "+ console.reset + console.green + ": %s" % uri.concert_name+ console.reset)
+        print("\t" + console.bold + "'Hardware Platform'     "+ console.reset + console.green + ": %s" % uri.hardware_platform.string + console.reset)
+        print("\t" + console.bold + "'Name'                  "+ console.reset + console.green + ": %s" % uri.name.string + console.reset)
+        print("\t" + console.bold + "'Application Framework' "+ console.reset + console.green + ": %s" % uri.application_framework.string + console.reset)
+        print("\t" + console.bold + "'Operating System'      "+ console.reset + console.green + ": %s" % uri.operating_system.string + console.reset)
+        if uri.rapp:
+            print("\t" + console.bold + "'Rapp'                  "+ console.reset + console.green + ": %s" % uri.rapp + console.reset)
     except rocon_uri.RoconURIValueError as e:
         print(console.bold + "\nError" + console.reset)
         print(console.red + "\tFailed to parse " +  console.cyan + rocon_uri_string + console.reset)


### PR DESCRIPTION
rocon_uri parse is more descriptive

```
    'rocon:/waiterbot/kobuki|chopin#cafe_rapps/waiter' is a valid rocon uri

    'Concert Name'          : 
    'Hardware Platform'     : waiterbot
    'Name'                  : kobuki|chopin
    'Application Framework' : *
    'Operating System'      : *
    'Rapp'                  : cafe_rapps/waiter
```
