### PR TITLE
Don't fail on wifi-if check for different systems

### DIFF
--- a/rocon_python_wifi/src/rocon_python_wifi/iwlibs.py
+++ b/rocon_python_wifi/src/rocon_python_wifi/iwlibs.py
@@ -73,14 +73,14 @@ def getWNICnames():
     """
     device = re.compile('[a-z]{2,}[0-9]*:')
     ifnames = []
-
-    fp = open('/proc/net/wireless', 'r')
-    for line in fp:
-        try:
-            # append matching pattern, without the trailing colon
-            ifnames.append(device.search(line).group()[:-1])
-        except AttributeError:
-            pass
+    if os.path.isfile('/proc/net/wireless'):
+        with open('/proc/net/wireless', 'r') as fp:
+            for line in fp:
+                try:
+                    # append matching pattern, without the trailing colon
+                    ifnames.append(device.search(line).group()[:-1])
+                except AttributeError:
+                    pass
     # if we couldn't lookup the devices, try to ask the kernel
     if ifnames == []:
         ifnames = getConfiguredWNICnames()


### PR DESCRIPTION
In wifi part of detection of network interfaces: Check if /proc/net/wireless exists before trying to read it, instead of failing on OS's / systems that don't have wifi and/or don't use that file.

---

`$ roslaunch rocon_gateway gateway.launch` was previously throwing an error for me when I tried to setup a minimal system and launch on my machine.

It is a Gentoo (3.14.14-gentoo) 64-bit system, running ROS Indigo, without any wireless network interfaces, but with two wired interfaces (one connected to the internet) -- (it's actually a Baxter Robot).  I don't really know what aspect of the system spec means it doesn't have the `/proc/net/wireless` file, but it doesn't.  So the launch would throw the following error:

```
rlinsalata@p26 ~/ws/rocon $ roslaunch rocon_gateway gateway.launch gateway_firewall:=false gateway_network_interface:=net0
... logging to /home/rlinsalata/.ros/log/aa923378-dd7b-11e4-ab41-90b11ca35e8f/roslaunch-p26-6019.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://p26:51192/

SUMMARY
========

PARAMETERS
 * /gateway/default_blacklist: [{'node': 'None',...
 * /gateway/disable_uuids: False
 * /gateway/firewall: False
 * /gateway/hub_whitelist: []
 * /gateway/name: gateway
 * /gateway/network_interface: net0
 * /gateway/watch_loop_period: 5
 * /rosdistro: indigo
 * /rosversion: 1.11.8

NODES
  /zeroconf/
    zeroconf (zeroconf_avahi/zeroconf)
  /
    gateway (rocon_gateway/gateway.py)

ROS_MASTER_URI=http://localhost:11311

core service [/rosout] found
process[zeroconf/zeroconf-1]: started with pid [6071]
process[gateway-2]: started with pid [6092]
[INFO] [WallTime: 1428615211.620333] Gateway : generated unique hash name [gateway2612f03968b0446d8a5c521b42b6aeb3]
[WARN] [WallTime: 1428615211.622570] Gateway : no valid ip found for this host, just setting 'localhost'
Traceback (most recent call last):
  File "/home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/scripts/gateway.py", line 21, in <module>
    gateway = GatewayNode()
  File "/home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/src/rocon_gateway/gateway_node.py", line 55, in __init__
    self._gateway = gateway.Gateway(self._hub_manager, self._param, self._unique_name, self._publish_gateway_info)
  File "/home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/src/rocon_gateway/gateway.py", line 74, in __init__
    self.network_interface_manager = NetworkInterfaceManager(self._param['network_interface'])
  File "/home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/src/rocon_gateway/network_interface_manager.py", line 36, in __init__
    self.detect_network_interface(interface_name)
  File "/home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/src/rocon_gateway/network_interface_manager.py", line 50, in detect_network_interface
    for interface in pythonwifi.getWNICnames():
  File "/home/rlinsalata/ws/rocon/src/rocon_tools/rocon_python_wifi/src/rocon_python_wifi/iwlibs.py", line 77, in getWNICnames
    fp = open('/proc/net/wireless', 'r')
IOError: [Errno 2] No such file or directory: '/proc/net/wireless'
[gateway-2] process has died [pid 6092, exit code 1, cmd /home/rlinsalata/ws/rocon/src/rocon_multimaster/rocon_gateway/scripts/gateway.py __name:=gateway __log:=/home/rlinsalata/.ros/log/aa923378-dd7b-11e4-ab41-90b11ca35e8f/gateway-2.log].
log file: /home/rlinsalata/.ros/log/aa923378-dd7b-11e4-ab41-90b11ca35e8f/gateway-2*.log
^C[zeroconf/zeroconf-1] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done

```
