### PR TITLE
Python comms introspection & no more special case bindings

### DIFF
--- a/rocon_interactions/src/rocon_interactions/interactions.py
+++ b/rocon_interactions/src/rocon_interactions/interactions.py
@@ -186,6 +186,17 @@ class Interaction(object):
         """
         return True if self.msg.pairing.rapp else False
 
+    def is_one_sided_paired_type(self):
+        """
+        Classify whether this interaction is a one sided pairing,
+        i.e. it is simply a rapp launcher.
+
+        :returns: whether it is a one sided pairing interaction or not
+        :rtype: bool
+        """
+        return True if self.msg.pairing.rapp and not self.name else False
+
+
     ##############################################################################
     # Conveniences
     ##############################################################################

--- a/rocon_interactions/src/rocon_interactions/ros_parameters.py
+++ b/rocon_interactions/src/rocon_interactions/ros_parameters.py
@@ -14,33 +14,6 @@ import rocon_console.console as console
 ###############################################################################
 
 
-class Bindings:
-    """
-    Special symbols that are substituted into yaml loaded interactions.
-
-    :ivar rosbridge_address: address of the rosbridge *['localhost']*
-    :vartype rosbridge_address: str
-    :ivar rosbridge_port: port to connect to a rosbridge *[9090]*
-    :vartype rosbridge_port: str
-    :ivar webserver_address: default location for where web apps can be found *['localhost']*
-    :vartype webserver_address: str
-    """
-    def __init__(self):
-        self.rosbridge_address = rospy.get_param('~rosbridge_address', "")
-        self.rosbridge_port = rospy.get_param('~rosbridge_port', 9090)
-        self.webserver_address = rospy.get_param('~webserver_address', 'localhost')
-        # processing
-        if self.rosbridge_address == "":
-            self.rosbridge_address = 'localhost'
-
-    def __str__(self):
-        s = console.bold + "\nBindings:\n" + console.reset
-        for key in sorted(self.__dict__):
-            s += console.cyan + "    %s: " % key + console.yellow + "%s\n" % (self.__dict__[key] if self.__dict__[key] is not None else '-')
-        s += console.reset
-        return s
-
-
 class Parameters:
     """
     The variables of this class are default constructed from parameters on the

--- a/rocon_interactions/tests/nose/Readme.md
+++ b/rocon_interactions/tests/nose/Readme.md
@@ -1,0 +1,4 @@
+Because I can never remember...execute with `nosetests my_test.py` in this folder.
+
+Right now, various options are in the setup.cfg (some problems with logging - see
+notes in the .cfg file).

--- a/rocon_interactions/tests/nose/setup.cfg
+++ b/rocon_interactions/tests/nose/setup.cfg
@@ -1,0 +1,14 @@
+[nosetests]
+
+# comment these out to get defaults, for some reason things like nocapture=0, False, FALSE detects as true
+
+# let everything go to standard output
+nocapture=1
+
+# I shouldn't have to do this, by default nosetest should capture all loggers and show them, even let us
+# set what level of logging we want from the logging-level variable but I'd be buggered if I can work
+# out why it doesn't work as expected
+nologcapture=1
+
+# use to get really detailed info from nosetests (e.g. 3), not often necessary
+#verbosity=1

--- a/rocon_interactions/tests/nose/test_interactions.py
+++ b/rocon_interactions/tests/nose/test_interactions.py
@@ -81,19 +81,20 @@ def test_web_urls():
     print("%s" % interactions_table)
     assert 'Web URLs' in interactions_table.roles()
 
-def test_web_apps():
-    print(console.bold + "\n****************************************************************************************" + console.reset)
-    print(console.bold + "* Web App Interactions" + console.reset)
-    print(console.bold + "****************************************************************************************" + console.reset)
-    print("")
+# This needs to move to a rostest to make use of the ros param server to do dynamic bindings
+# def test_web_apps():
+#     print(console.bold + "\n****************************************************************************************" + console.reset)
+#     print(console.bold + "* Web App Interactions" + console.reset)
+#     print(console.bold + "****************************************************************************************" + console.reset)
+#     print("")
+# 
+#     interactions_table = rocon_interactions.InteractionsTable()
+#     msg_interactions = load_interactions('rocon_interactions/web_apps')
+#     assert msg_interactions is not None, 'malformed yaml [rocon_interactions/web_apps]'
+#     interactions_table.load(msg_interactions)
+#     print("%s" % interactions_table)
+#     assert 'Web Apps' in interactions_table.roles()
 
-    interactions_table = rocon_interactions.InteractionsTable()
-    msg_interactions = load_interactions('rocon_interactions/web_apps')
-    assert msg_interactions is not None, 'malformed yaml [rocon_interactions/web_apps]'
-    interactions_table.load(msg_interactions)
-    print("%s" % interactions_table)
-    assert 'Web Apps' in interactions_table.roles()
-  
 def test_removal():
     print(console.bold + "\n****************************************************************************************" + console.reset)
     print(console.bold + "* Removal" + console.reset)

--- a/rocon_master_info/CMakeLists.txt
+++ b/rocon_master_info/CMakeLists.txt
@@ -24,3 +24,5 @@ install(
         scripts/master.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/rocon_python_comms/src/rocon_python_comms/utils.py
+++ b/rocon_python_comms/src/rocon_python_comms/utils.py
@@ -42,7 +42,7 @@ def publish_resolved_names(publisher, ros_communication_handles):
 
 
 class Services(object):
-    def __init__(self, services, introspection_topic_name="~services"):
+    def __init__(self, services, introspection_topic_name="services"):
         """
         Converts the incoming list of service name, service type, callback function triples into proper variables of this class.
 
@@ -51,13 +51,13 @@ class Services(object):
         :param str introspection_topic_name: where to put the introspection topic that shows the resolved names at runtime
         """
         self.__dict__ = {namespace.basename(service_name): rospy.Service(service_name, service_type, callback) for (service_name, service_type, callback) in services}
-        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publisher = rospy.Publisher("~introspection/" + introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
         publish_resolved_names(publisher, self.__dict__.values())
         self.introspection_publisher = publisher
 
 
 class ServiceProxies(object):
-    def __init__(self, service_proxies, introspection_topic_name="~service_proxies"):
+    def __init__(self, service_proxies, introspection_topic_name="service_proxies"):
         """
         Converts the incoming list of service name, service type pairs into proper variables of this class.
 
@@ -65,13 +65,13 @@ class ServiceProxies(object):
         :type services: list of (str, str) tuples representing (service_name, service_type) pairs.
         """
         self.__dict__ = {namespace.basename(service_name): rospy.ServiceProxy(service_name, service_type) for (service_name, service_type) in service_proxies}
-        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publisher = rospy.Publisher("~introspection/" + introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
         publish_resolved_names(publisher, self.__dict__.values())
         self.introspection_publisher = publisher
 
 
 class Publishers(object):
-    def __init__(self, publishers, introspection_topic_name="~publishers"):
+    def __init__(self, publishers, introspection_topic_name="publishers"):
         """
         Converts the incoming list of publisher name, type, latched, queue_size specifications into proper variables of this class.
 
@@ -79,13 +79,13 @@ class Publishers(object):
         :type publishers: list of (str, str, bool, int) tuples representing (topic_name, publisher_type, latched, queue_size) specifications.
         """
         self.__dict__ = {namespace.basename(topic_name): rospy.Publisher(topic_name, publisher_type, latch=latched, queue_size=queue_size) for (topic_name, publisher_type, latched, queue_size) in publishers}
-        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publisher = rospy.Publisher("~introspection/" + introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
         publish_resolved_names(publisher, self.__dict__.values())
         self.introspection_publisher = publisher
 
 
 class Subscribers(object):
-    def __init__(self, subscribers, introspection_topic_name="~subscribers"):
+    def __init__(self, subscribers, introspection_topic_name="subscribers"):
         """
         Converts the incoming list of publisher name, service type pairs into proper variables of this class.
 
@@ -93,7 +93,7 @@ class Subscribers(object):
         :type subscribers: list of (str, str, bool, int) tuples representing (topic_name, subscriber_type, latched, queue_size) specifications.
         """
         self.__dict__ = {namespace.basename(topic_name): rospy.Subscriber(topic_name, subscriber_type, callback) for (topic_name, subscriber_type, callback) in subscribers}
-        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publisher = rospy.Publisher("~introspection/" + introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
         publish_resolved_names(publisher, self.__dict__.values())
         self.introspection_publisher = publisher
 

--- a/rocon_python_comms/src/rocon_python_comms/utils.py
+++ b/rocon_python_comms/src/rocon_python_comms/utils.py
@@ -20,7 +20,9 @@ Convenience utilities for ros 1.0 python communications.
 # Imports
 ##############################################################################
 
+import rocon_console.console as console
 import rospy
+import std_msgs.msg as std_msgs
 from . import namespace
 
 ##############################################################################
@@ -28,19 +30,34 @@ from . import namespace
 ##############################################################################
 
 
-class Services:
-    def __init__(self, services):
+def publish_resolved_names(publisher, ros_communication_handles):
+    """
+    Worker that provides a string representation of all the resolved names
+    and publishes it so we can use it as an introspection topic in runtime.
+    """
+    s = console.bold + "\nResolved Names\n\n" + console.reset
+    for handle in ros_communication_handles:
+        s += console.yellow + "  " + handle.resolved_name + "\n" + console.reset
+        publisher.publish(std_msgs.String("%s" % s))
+
+
+class Services(object):
+    def __init__(self, services, introspection_topic_name="~services"):
         """
         Converts the incoming list of service name, service type, callback function triples into proper variables of this class.
 
         :param services: incoming list of service specifications
         :type services: list of (str, str, function) tuples representing (service_name, service_type, callback) pairs.
+        :param str introspection_topic_name: where to put the introspection topic that shows the resolved names at runtime
         """
         self.__dict__ = {namespace.basename(service_name): rospy.Service(service_name, service_type, callback) for (service_name, service_type, callback) in services}
+        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publish_resolved_names(publisher, self.__dict__.values())
+        self.introspection_publisher = publisher
 
 
-class ServiceProxies:
-    def __init__(self, service_proxies):
+class ServiceProxies(object):
+    def __init__(self, service_proxies, introspection_topic_name="~service_proxies"):
         """
         Converts the incoming list of service name, service type pairs into proper variables of this class.
 
@@ -48,10 +65,13 @@ class ServiceProxies:
         :type services: list of (str, str) tuples representing (service_name, service_type) pairs.
         """
         self.__dict__ = {namespace.basename(service_name): rospy.ServiceProxy(service_name, service_type) for (service_name, service_type) in service_proxies}
+        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publish_resolved_names(publisher, self.__dict__.values())
+        self.introspection_publisher = publisher
 
 
-class Publishers:
-    def __init__(self, publishers):
+class Publishers(object):
+    def __init__(self, publishers, introspection_topic_name="~publishers"):
         """
         Converts the incoming list of publisher name, type, latched, queue_size specifications into proper variables of this class.
 
@@ -59,10 +79,13 @@ class Publishers:
         :type publishers: list of (str, str, bool, int) tuples representing (topic_name, publisher_type, latched, queue_size) specifications.
         """
         self.__dict__ = {namespace.basename(topic_name): rospy.Publisher(topic_name, publisher_type, latch=latched, queue_size=queue_size) for (topic_name, publisher_type, latched, queue_size) in publishers}
+        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publish_resolved_names(publisher, self.__dict__.values())
+        self.introspection_publisher = publisher
 
 
-class Subscribers:
-    def __init__(self, subscribers):
+class Subscribers(object):
+    def __init__(self, subscribers, introspection_topic_name="~subscribers"):
         """
         Converts the incoming list of publisher name, service type pairs into proper variables of this class.
 
@@ -70,3 +93,6 @@ class Subscribers:
         :type subscribers: list of (str, str, bool, int) tuples representing (topic_name, subscriber_type, latched, queue_size) specifications.
         """
         self.__dict__ = {namespace.basename(topic_name): rospy.Subscriber(topic_name, subscriber_type, callback) for (topic_name, subscriber_type, callback) in subscribers}
+        publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
+        publish_resolved_names(publisher, self.__dict__.values())
+        self.introspection_publisher = publisher

--- a/rocon_python_comms/src/rocon_python_comms/utils.py
+++ b/rocon_python_comms/src/rocon_python_comms/utils.py
@@ -26,7 +26,7 @@ import std_msgs.msg as std_msgs
 from . import namespace
 
 ##############################################################################
-# Classes
+# Mass Ros Communication Factories
 ##############################################################################
 
 
@@ -96,3 +96,11 @@ class Subscribers(object):
         publisher = rospy.Publisher(introspection_topic_name, std_msgs.String, latch=True, queue_size=1)
         publish_resolved_names(publisher, self.__dict__.values())
         self.introspection_publisher = publisher
+
+##############################################################################
+# Parameters
+##############################################################################
+
+# Use a class decorator to extend a user's Parameter class
+# http://python-3-patterns-idioms-test.readthedocs.org/en/latest/PythonDecorators.html
+# http://stackoverflow.com/questions/9443725/add-method-to-a-class-dynamically-with-decorator

--- a/rocon_python_comms/src/rocon_python_comms/utils.py
+++ b/rocon_python_comms/src/rocon_python_comms/utils.py
@@ -46,6 +46,8 @@ class Services(object):
         """
         Converts the incoming list of service name, service type, callback function triples into proper variables of this class.
 
+        Note: '~/introspection/dude' will become just 'dude'
+
         :param services: incoming list of service specifications
         :type services: list of (str, str, function) tuples representing (service_name, service_type, callback) pairs.
         :param str introspection_topic_name: where to put the introspection topic that shows the resolved names at runtime
@@ -61,6 +63,8 @@ class ServiceProxies(object):
         """
         Converts the incoming list of service name, service type pairs into proper variables of this class.
 
+        Note: '~/introspection/dude' will become just 'dude'
+
         :param services: incoming list of service proxy specifications
         :type services: list of (str, str) tuples representing (service_name, service_type) pairs.
         """
@@ -75,6 +79,8 @@ class Publishers(object):
         """
         Converts the incoming list of publisher name, type, latched, queue_size specifications into proper variables of this class.
 
+        Note: '~/introspection/dude' will become just 'dude'
+
         :param publishers: incoming list of service specifications
         :type publishers: list of (str, str, bool, int) tuples representing (topic_name, publisher_type, latched, queue_size) specifications.
         """
@@ -88,6 +94,8 @@ class Subscribers(object):
     def __init__(self, subscribers, introspection_topic_name="subscribers"):
         """
         Converts the incoming list of publisher name, service type pairs into proper variables of this class.
+
+        Note: '~/introspection/dude' will become just 'dude'
 
         :param subscribers: incoming list of service specifications
         :type subscribers: list of (str, str, bool, int) tuples representing (topic_name, subscriber_type, latched, queue_size) specifications.

--- a/rocon_python_comms/tests/rostests/utils/test_utils.py
+++ b/rocon_python_comms/tests/rostests/utils/test_utils.py
@@ -31,6 +31,11 @@ def subscriber_callback(msg):
 
 class TestUtils(unittest.TestCase):
     def test_services(self):
+        print("")
+        print(console.bold + "\n****************************************************************************************" + console.reset)
+        print(console.bold + "* Services" + console.reset)
+        print(console.bold + "****************************************************************************************" + console.reset)
+        print("")
         services = rocon_python_comms.utils.Services(
             [
                 ('~dude', std_srvs.Empty, service_callback),
@@ -40,7 +45,27 @@ class TestUtils(unittest.TestCase):
         assert ('dude' in services.__dict__.keys())
         assert ('bob' in services.__dict__.keys())
 
+    def test_service_proxies(self):
+        print("")
+        print(console.bold + "\n****************************************************************************************" + console.reset)
+        print(console.bold + "* Service Proxies" + console.reset)
+        print(console.bold + "****************************************************************************************" + console.reset)
+        print("")
+        service_proxies = rocon_python_comms.utils.ServiceProxies(
+            [
+                ('~dude', std_srvs.Empty),
+                ('/dude/bob', std_srvs.Empty),
+            ]
+        )
+        assert ('dude' in service_proxies.__dict__.keys())
+        assert ('bob' in service_proxies.__dict__.keys())
+
     def test_publishers(self):
+        print("")
+        print(console.bold + "\n****************************************************************************************" + console.reset)
+        print(console.bold + "* Publishers" + console.reset)
+        print(console.bold + "****************************************************************************************" + console.reset)
+        print("")
         publishers = rocon_python_comms.utils.Publishers(
             [
                 ('~foo', std_msgs.String, True, 5),
@@ -51,6 +76,11 @@ class TestUtils(unittest.TestCase):
         assert('bar' in publishers.__dict__.keys())
 
     def test_subscribers(self):
+        print("")
+        print(console.bold + "\n****************************************************************************************" + console.reset)
+        print(console.bold + "* Subscribers" + console.reset)
+        print(console.bold + "****************************************************************************************" + console.reset)
+        print("")
         subscribers = rocon_python_comms.utils.Subscribers(
             [
                 ('~dudette', std_msgs.String, subscriber_callback),


### PR DESCRIPTION
- Convenience Subscriber, Publisher, Services, Service Proxy classes now provide an introspection topic.
- Interactions removed the special case bindings, dynamics can serve these well enough
- Fixed the test failure in rocon_interactions
