### PR TITLE
Interaction pairings support for rapp parameters

### DIFF
--- a/rocon_interactions/interactions/pairing.interactions
+++ b/rocon_interactions/interactions/pairing.interactions
@@ -8,6 +8,9 @@ pairings:
       remappings:
           - remap_from: chatter
             remap_to: /conversation/chatter
+      parameters:
+          - key: message
+            value: "gday dude"
     - name: Babbler
       rapp: rocon_apps/talker
       description: Talker remapped to a babbler.

--- a/rocon_interactions/src/rocon_interactions/manager.py
+++ b/rocon_interactions/src/rocon_interactions/manager.py
@@ -463,7 +463,7 @@ class InteractionsManager(object):
                     response = utils.generate_request_interaction_response(interaction_msgs.ErrorCodes.PAIRING_UNAVAILABLE)
                     return response
                 try:
-                    self._rapp_handler.start(pairing.rapp, pairing.remappings)
+                    self._rapp_handler.start(pairing.rapp, pairing.remappings, pairing.parameters)
                     self.active_pairing = pairing
                 except FailedToStartRappError as e:
                     rospy.loginfo("Interactions : rejected interaction request [failed to start the paired rapp]")
@@ -488,7 +488,7 @@ class InteractionsManager(object):
         try:
             pairing = self.pairings_table.find(request.name)
             self.active_pairing = pairing
-            self._rapp_handler.start(pairing.rapp, pairing.remappings)
+            self._rapp_handler.start(pairing.rapp, pairing.remappings, pairing.parameters)
             return interaction_srvs.StartPairingResponse(interaction_msgs.ErrorCodes.SUCCESS, "firing up.")
         except FailedToStartRappError as e:
             rospy.loginfo("Interactions : rejected interaction request [failed to start the paired rapp]")

--- a/rocon_interactions/src/rocon_interactions/rapp_handler.py
+++ b/rocon_interactions/src/rocon_interactions/rapp_handler.py
@@ -148,13 +148,15 @@ class RappHandler(object):
         except KeyError:
             return None
 
-    def start(self, rapp, remappings):
+    def start(self, rapp, remappings, parameters=[]):
         """
         Start the rapp with the specified remappings.
 
         :param str rapp: ros package resource name of the rapp to start (e.g. rocon_apps/teleop)
         :param remappings: remappings to apply to the rapp when starting.
         :type remappings: [rocon_std_msgs.Remapping]
+        :param parameters: paramters to apply to the rapp when starting.
+        :type remappings: [rocon_std_msgs.KeyValue]
 
         .. include:: weblinks.rst
 
@@ -163,7 +165,7 @@ class RappHandler(object):
         if not self.initialised:
             raise FailedToStartRappError("rapp manager's location unknown")
         try:
-            unused_response = self.service_proxies.start_rapp(rocon_app_manager_srvs.StartRappRequest(name=rapp, remappings=remappings))
+            unused_response = self.service_proxies.start_rapp(rocon_app_manager_srvs.StartRappRequest(name=rapp, remappings=remappings, parameters=parameters))
             # todo check this response and process it
         except (rospy.service.ServiceException,
                 rospy.exceptions.ROSInterruptException) as e:


### PR DESCRIPTION
This was accidentally forgotten. Now supported. To test:

```
# in one shell
$ roslaunch rocon_app_manager pairing_demo.launch --screen
# in another
$ rqt_remocon
```

And start the talker pairing. The message should be `hello dude` instead of the default `hello world`.

You can see the yaml setting format for this in `rocon_interactions/interactions/pairing.interactions`.
