### PR TITLE
Add gocart_mini to rocon_uri rules

### DIFF
--- a/rocon_uri/src/rocon_uri/rules/rules.yaml
+++ b/rocon_uri/src/rocon_uri/rules/rules.yaml
@@ -6,6 +6,7 @@
     - gocart
     - gocart_v1
     - gocart_v2
+    - gocart_mini
     - gopher
     - kobuki
     - korus


### PR DESCRIPTION
Anything else to do for rocon to add a new robot type?
