### PR TITLE
Add gocart mini(v2.1)

### DIFF
--- a/rocon_uri/src/rocon_uri/rules/rules.yaml
+++ b/rocon_uri/src/rocon_uri/rules/rules.yaml
@@ -8,6 +8,7 @@
     - gocart_v2
     - gocart_v2_1
     - gocart_mini
+    - gocart_mini_v2_1
     - gopher
     - kobuki
     - korus


### PR DESCRIPTION
Now we are using gocart_mini_v2_1 for gocart mini 2.1 version. It needs to update rules file of the ROCON URI.